### PR TITLE
Use securecookies for login/out

### DIFF
--- a/api.go
+++ b/api.go
@@ -135,6 +135,7 @@ func setLogin()(c *http.Cookie) {
             Name:  "s3-club-7",
             Value: encoded,
             Path:  "/",
+            Secure: true,
         }
     }
 

--- a/api.go
+++ b/api.go
@@ -27,10 +27,13 @@ func Router(w http.ResponseWriter, r *http.Request) {
     resp.Time = time.Now().Format(time.RFC3339)
     resp.Body.Success = true
 
-    switch {
-    case r.Method == "POST" && r.URL.Path == "/":
-        r.ParseMultipartForm(32 << 20)
+    r.ParseMultipartForm(32 << 20)
 
+    switch {
+    case r.Method == "OPTIONS":
+
+
+    case r.Method == "POST" && r.URL.Path == "/session":
         a := Auth{Username: r.FormValue("username"), Password: r.FormValue("password"), URL: *flexUrl}
         if err := a.Valid(); err != nil {
             resp.Status = http.StatusUnauthorized
@@ -38,8 +41,24 @@ func Router(w http.ResponseWriter, r *http.Request) {
             resp.Body.Success = false
 
             resp.respond(w)
-            return
+        } else {
+            http.SetCookie(w, setLogin())
+            resp.Body.Message = "logged in"
         }
+
+
+    case r.Method == "GET" && r.URL.Path == "/session":
+        if isLoggedIn(r) {
+            resp.Body.Message = "logged in"
+        } else {
+            resp.Status = http.StatusUnauthorized
+            resp.Body.Message = "not logged in"
+            resp.Body.Success = false
+        }
+
+
+    case r.Method == "POST" && r.URL.Path == "/upload":
+        r.ParseMultipartForm(32 << 20)
 
         uploadFile, handler, err := r.FormFile("upload")
         if err != nil {
@@ -74,6 +93,7 @@ func Router(w http.ResponseWriter, r *http.Request) {
             log.Printf("Error cleaning up: %s", err.Error())
         }
 
+
     default:
         resp.Status = http.StatusNotFound
         resp.Body.Message = "Not found"
@@ -92,7 +112,45 @@ func LogRequest(r *http.Request) {
 }
 
 func (r Response) respond (w http.ResponseWriter) {
+    w.Header().Set("Access-Control-Allow-Headers", "requested-with, Content-Type, origin, authorization, accept, client-security-token, cache-control, x-api-key")
+    w.Header().Set("Access-Control-Allow-Methods", "POST, GET, OPTIONS, PUT")
+    w.Header().Set("Access-Control-Allow-Origin", "*")
+    w.Header().Set("Access-Control-Max-Age", "10000")
+    w.Header().Set("Cache-Control", "no-cache")
+
+    w.Header().Set("Content-Type", "application/json")
+
     w.WriteHeader(r.Status)
     j,_ := json.Marshal(r)
+
     fmt.Fprintf(w, string(j))
+}
+
+func setLogin()(c *http.Cookie) {
+    value := map[string]string{
+        "loggedin": "true",
+    }
+    if encoded, err := CookieStore.Encode("s3-club-7", value); err == nil {
+        c = &http.Cookie{
+            Name:  "s3-club-7",
+            Value: encoded,
+            Path:  "/",
+        }
+    }
+
+    return c
+}
+
+func isLoggedIn(r *http.Request)(bool) {
+    if cookie, err := r.Cookie("s3-club-7"); err == nil {
+        value := make(map[string]string)
+
+        if err = CookieStore.Decode("s3-club-7", cookie.Value, &value); err == nil {
+            if value["loggedin"] == "true" {
+                return true
+            }
+        }
+    }
+
+    return false
 }

--- a/main.go
+++ b/main.go
@@ -4,20 +4,47 @@ import (
     "flag"
     "log"
     "net/http"
+
+    "github.com/gorilla/securecookie"
 )
 
+var blockKey []byte
 var clusterid *string
 var flexUrl *string
+var hashKey []byte
+
+var CookieStore *securecookie.SecureCookie
 
 func init() {
     clusterid = flag.String("cluster", "", "flex cluster to run under")
     flexUrl = flag.String("flex-api", "https://flex.example.com/api", "Flex API Url to validate creds against")
+
+    blockKeyString := flag.String("block-key", "", "AES Key to encrypt secure cookie with. 32 bytes suggested")
+    hashKeyString := flag.String("hmac-key", "", "HMAC-specific key. 64 bytes suggested")
 
     flag.Parse()
 
     if *clusterid == "" {
         log.Fatal("No flex cluster defined, please specify on the cli")
     }
+
+    if *blockKeyString == "" {
+        if blockKey = securecookie.GenerateRandomKey(32); blockKey == nil {
+            log.Fatal("Couldn't generate a block key. Suggest specifying one on the cli")
+        }
+    } else {
+        blockKey = []byte(*blockKeyString)
+    }
+
+    if *hashKeyString == "" {
+        if hashKey = securecookie.GenerateRandomKey(64); hashKey == nil {
+            log.Fatal("Couldn't generate an HMACkey. Suggest specifying one on the cli")
+        }
+    } else {
+        hashKey = []byte(*hashKeyString)
+    }
+
+    CookieStore = securecookie.New(hashKey, blockKey)
 }
 
 func main() {


### PR DESCRIPTION
Currently ever upload is passed the login creds. While this means that each upload has it's creds checked it does also mean that the feedback for bad logins is wrong: editors wont know they can't login (for whatever reason) until they press the upload button.

Thus we're going to use cookies. We use cookies over sessions because we want the `s3-club-7` instances to be stateless. We use *secure cookies* to stop people  mucking about with them.

So long as each `s3-club-7` in a cluster used the same set of keys on the cli then this will work fine.

There are new routes:

`POST /session`
  * Takes username and password form fields

`GET /session`
  * Returns whether logged in or not

`POST /upload`
  * The old `/` route
  * Same payload, minus username and password 