### PR TITLE
**RFC:** Ensure cors allows cookies through

### DIFF
--- a/api.go
+++ b/api.go
@@ -68,7 +68,14 @@ func Router(w http.ResponseWriter, r *http.Request) {
 
 
     case r.Method == "POST" && r.URL.Path == "/upload":
-        r.ParseMultipartForm(32 << 20)
+        if !loggedIn {
+            resp.Status = http.StatusUnauthorized
+            resp.Body.Message = "not logged in"
+            resp.Body.Success = false
+
+            resp.respond(w)
+            return
+        }
 
         uploadFile, handler, err := r.FormFile("upload")
         if err != nil {

--- a/api.go
+++ b/api.go
@@ -21,6 +21,12 @@ type ResponseBody struct {
     Message string
 }
 
+const (
+    cookieAge = 43200
+    cookieName = "s3-club-7"
+)
+
+
 func Router(w http.ResponseWriter, r *http.Request) {
     loggedIn, username := isLoggedIn(r)
     LogRequest(r, username)
@@ -150,12 +156,13 @@ func setLogin(username string)(c *http.Cookie) {
         "loggedin": "true",
         "username": username,
     }
-    if encoded, err := CookieStore.Encode("s3-club-7", value); err == nil {
+    if encoded, err := CookieStore.Encode(cookieName, value); err == nil {
         c = &http.Cookie{
-            Name:  "s3-club-7",
-            Value: encoded,
+            MaxAge: cookieAge,
+            Name:  cookieName,
             Path:  "/",
             Secure: !*development,
+            Value: encoded,
         }
     } else {
         log.Println(err)
@@ -165,10 +172,10 @@ func setLogin(username string)(c *http.Cookie) {
 }
 
 func isLoggedIn(r *http.Request)(loggedIn bool, username string) {
-    if cookie, err := r.Cookie("s3-club-7"); err == nil {
+    if cookie, err := r.Cookie(cookieName); err == nil {
         value := make(map[string]string)
 
-        if err = CookieStore.Decode("s3-club-7", cookie.Value, &value); err == nil {
+        if err = CookieStore.Decode(cookieName, cookie.Value, &value); err == nil {
             if value["loggedin"] == "true" {
                 return true, value["username"]
             }

--- a/auth.go
+++ b/auth.go
@@ -13,6 +13,10 @@ type Auth struct {
 }
 
 func (a *Auth) Valid() error {
+    if *development {
+        return nil
+    }
+
     var req *http.Request
     var resp *http.Response
     var err error

--- a/aws.go
+++ b/aws.go
@@ -15,6 +15,11 @@ var output *s3.PutObjectOutput
 var err error
 
 func (u *Uploader)UploadData()(out string, e error) {
+    if *development {
+        out = "upload to s3 is disabled in development mode"
+        return
+    }
+
     if projectData, err = ioutil.ReadFile(u.tmpFile.Name()); err != nil {
         e = err
         return

--- a/main.go
+++ b/main.go
@@ -13,11 +13,14 @@ var clusterid *string
 var flexUrl *string
 var hashKey []byte
 
+var development *bool
+
 var CookieStore *securecookie.SecureCookie
 
 func init() {
     clusterid = flag.String("cluster", "", "flex cluster to run under")
     flexUrl = flag.String("flex-api", "https://flex.example.com/api", "Flex API Url to validate creds against")
+    development = flag.Bool("dev", false, "When running in dev mode we disable things like secure cookies")
 
     blockKeyString := flag.String("block-key", "", "AES Key to encrypt secure cookie with. 32 bytes suggested")
     hashKeyString := flag.String("hmac-key", "", "HMAC-specific key. 64 bytes suggested")
@@ -51,6 +54,10 @@ func main() {
     log.Printf( "Creating projects under the %s cluster", *clusterid )
     log.Printf( "Authenticating against %s", *flexUrl )
     log.Printf( "Listening on port %d", 8000)
+
+    if *development {
+        log.Print("**IN DEV MODE**")
+    }
 
     http.HandleFunc("/", Router)
     http.ListenAndServe(":8000", nil)


### PR DESCRIPTION
Note: this PR also includes changes to help in development and a bug fix to `POST /upload`

This PR is in RFC, do not merge.

XHR doesn't like our CORS headers, thus not setting cookies. This means authentication bombs. This PR contains a multitude of fixes for this issue.
